### PR TITLE
Add dependabot.yml to instruct bot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 1
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    target-branch: 'dev'


### PR DESCRIPTION
The rationale of this PR is to control dependency updates.